### PR TITLE
Fix error happening when there is an error while using the Streaming api

### DIFF
--- a/lib/openai/internal/stream.rb
+++ b/lib/openai/internal/stream.rb
@@ -41,7 +41,7 @@ module OpenAI
                 OpenAI::Errors::APIError.for(
                   url: @url,
                   status: @status,
-                  body: body,
+                  body: nil, # When streaming, there is no equivalent to the raw response body, the information is present in the message.
                   request: nil,
                   response: @response,
                   message: message


### PR DESCRIPTION
The body method is undefined when we are in streaming mode.